### PR TITLE
Add Undo and Redo

### DIFF
--- a/src/components/ConfirmDelete.vue
+++ b/src/components/ConfirmDelete.vue
@@ -32,7 +32,8 @@
 
 <script lang="ts" setup>
 
-  import type { GameRecord } from '@/utils';
+  import { updateGame } from '@/game';
+import type { GameRecord } from '@/utils';
 import { notify } from '@kyvg/vue3-notification';
 import { set, type DatabaseReference } from 'firebase/database';
 import type { VueDatabaseDocumentData } from 'vuefire';
@@ -52,13 +53,12 @@ const confirm = async() => {
     await new Promise(r => setTimeout(r, 2000))
 
     const newObj: GameRecord = JSON.parse(JSON.stringify(props.gamesDbObj));
+    const oldObj: GameRecord = JSON.parse(JSON.stringify(props.gamesDbObj));
     newObj.boundaryLineEntries = [];
     newObj.customPins = [];
     newObj.polygonEntries = [];
     newObj.radarEntries = [];
-    await set(
-        props.gamesDbRef, newObj
-    );
+    await updateGame(newObj, oldObj, props.gamesDbRef);
     loading.value = false
     model.value = false
     notify({

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -302,6 +302,7 @@ const locate = () => {
 
 
 const addThermometer = async (lat: number, long: number, angle: number, hotter: boolean) => {
+    const oldGameObj = JSON.parse(JSON.stringify(gamesObj.value))
     const newEntries = gamesObj.value?.thermometerEntries ?? [];
     newEntries.push({
         lat: lat,
@@ -312,14 +313,12 @@ const addThermometer = async (lat: number, long: number, angle: number, hotter: 
         creatorName: user.value?.providerData[0].displayName ?? 'Unknown',
     });
 
-    await updateGame({
-        thermometerEntries: newEntries,
-        ...gamesObj.value
-    } as GameRecord, JSON.parse(JSON.stringify(gamesObj.value)), gamesDbRef.value);
+    await updateGame(gamesObj.value!, oldGameObj, gamesDbRef.value);
 };
 
 
 const addRadar = async (hit: boolean, lat: number, long: number, meters: number) => {
+    const oldGameObj = JSON.parse(JSON.stringify(gamesObj.value));
     const newEntries = gamesObj.value?.radarEntries ?? [];
     newEntries.push({
         lat: lat,
@@ -330,13 +329,11 @@ const addRadar = async (hit: boolean, lat: number, long: number, meters: number)
         creatorName: user.value?.providerData[0].displayName ?? 'Unknown'
     });
 
-    await updateGame({
-        radarEntries: newEntries,
-        ...gamesObj.value
-    } as GameRecord, JSON.parse(JSON.stringify(gamesObj.value)), gamesDbRef.value);
+    await updateGame(gamesObj.value!, oldGameObj, gamesDbRef.value);
 };
 
 const addBoundaryLine = async (lat: number, long: number, degrees: number) => {
+    const oldGameObj = JSON.parse(JSON.stringify(gamesObj.value));
     const newEntries = gamesObj.value?.boundaryLineEntries ?? [];
     newEntries.push({
         lat: lat,
@@ -346,10 +343,7 @@ const addBoundaryLine = async (lat: number, long: number, degrees: number) => {
         creatorName: user.value?.providerData[0].displayName ?? 'Unknown',
     });
 
-    await updateGame({
-        boundaryLineEntries: newEntries,
-        ...gamesObj.value
-    } as GameRecord, JSON.parse(JSON.stringify(gamesObj.value)), gamesDbRef.value);
+    await updateGame(gamesObj.value!, oldGameObj, gamesDbRef.value);
 }
 
 const displayRadar = (hit: boolean, lat: number, long: number, meters: number) => {
@@ -597,6 +591,7 @@ const draw = () => {
 
 const onMapClick: L.LeafletMouseEventHandlerFn = (e) => {
     if (droppingPin.value) {
+        const oldGameObj = JSON.parse(JSON.stringify(gamesObj.value));
         const newEntries = gamesObj.value?.customPins ?? [];
         newEntries.push({
             lat: e.latlng.lat,
@@ -606,11 +601,8 @@ const onMapClick: L.LeafletMouseEventHandlerFn = (e) => {
         });
         mostRecentlyDroppedPin.value = e.latlng;
         updateGame(
-            {
-                customPins: newEntries,
-                ...gamesObj.value
-            } as GameRecord,
-            JSON.parse(JSON.stringify(gamesObj.value)),
+            gamesObj.value!,
+            oldGameObj,
             gamesDbRef.value
         );
         droppingPin.value = false
@@ -660,6 +652,7 @@ onMounted(async () => {
 
         console.log(e);
         if (e.type == "draw:created" && (e as any).layerType == "polygon") {
+            const oldGameObj = JSON.parse(JSON.stringify(gamesObj.value));
             const newEntries = gamesObj.value?.polygonEntries ?? [];
             newEntries.push({
                 points: e.layer.editing.latlngs,
@@ -668,11 +661,8 @@ onMounted(async () => {
             });
 
             updateGame(
-                {
-                    polygonEntries: newEntries,
-                    ...gamesObj.value,
-                } as GameRecord,
-                JSON.parse(JSON.stringify(gamesObj.value)),
+                gamesObj.value!,
+                oldGameObj,
                 gamesDbRef.value
             );
             drawingPolygon.value = false

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -114,6 +114,7 @@ import '../styles/leaflet.draw.css';
 import { flipCoords, loadRegion } from '@/regions/regions';
 import { getIconFor } from '@/regions/icons';
 import { getFeatureMarkers, type FeatureType, type GetPopupFunction } from '@/regions/features';
+import { updateGame } from '@/game';
 
 const store = useStore();
 const localMap = shallowRef<L.Map | null>(null);
@@ -311,12 +312,10 @@ const addThermometer = async (lat: number, long: number, angle: number, hotter: 
         creatorName: user.value?.providerData[0].displayName ?? 'Unknown',
     });
 
-    await set(
-        gamesDbRef.value, {
+    await updateGame({
         thermometerEntries: newEntries,
         ...gamesObj.value
-    }
-    );
+    } as GameRecord, JSON.parse(JSON.stringify(gamesObj.value)), gamesDbRef.value);
 };
 
 
@@ -331,12 +330,10 @@ const addRadar = async (hit: boolean, lat: number, long: number, meters: number)
         creatorName: user.value?.providerData[0].displayName ?? 'Unknown'
     });
 
-    await set(
-        gamesDbRef.value, {
+    await updateGame({
         radarEntries: newEntries,
         ...gamesObj.value
-    }
-    );
+    } as GameRecord, JSON.parse(JSON.stringify(gamesObj.value)), gamesDbRef.value);
 };
 
 const addBoundaryLine = async (lat: number, long: number, degrees: number) => {
@@ -349,12 +346,10 @@ const addBoundaryLine = async (lat: number, long: number, degrees: number) => {
         creatorName: user.value?.providerData[0].displayName ?? 'Unknown',
     });
 
-    await set(
-        gamesDbRef.value, {
+    await updateGame({
         boundaryLineEntries: newEntries,
         ...gamesObj.value
-    }
-    );
+    } as GameRecord, JSON.parse(JSON.stringify(gamesObj.value)), gamesDbRef.value);
 }
 
 const displayRadar = (hit: boolean, lat: number, long: number, meters: number) => {
@@ -581,9 +576,10 @@ const finishMeasuringOtherMarker = (lat: number, long: number) => {
 
 const deleteCustomMarker = async (lat: number, long: number) => {
     const newObj: GameRecord = JSON.parse(JSON.stringify(gamesObj.value));
+    const oldObj: GameRecord = JSON.parse(JSON.stringify(gamesObj.value));
     newObj.customPins = newObj.customPins.filter(item => item.lat != lat || item.long != long);
-    await set(
-        gamesDbRef.value, newObj
+    await updateGame(
+        newObj, oldObj, gamesDbRef.value
     );
     completeRebuild()
 }
@@ -609,11 +605,14 @@ const onMapClick: L.LeafletMouseEventHandlerFn = (e) => {
             creatorName: user.value?.providerData[0].displayName ?? 'Unknown'
         });
         mostRecentlyDroppedPin.value = e.latlng;
-        set(
-            gamesDbRef.value, {
-            customPins: newEntries,
-            ...gamesObj.value
-        });
+        updateGame(
+            {
+                customPins: newEntries,
+                ...gamesObj.value
+            } as GameRecord,
+            JSON.parse(JSON.stringify(gamesObj.value)),
+            gamesDbRef.value
+        );
         droppingPin.value = false
         notify({
             type: 'success',
@@ -668,11 +667,13 @@ onMounted(async () => {
                 creatorName: user.value?.providerData[0].displayName ?? 'Unknown',
             });
 
-            set(
-                gamesDbRef.value, {
-                polygonEntries: newEntries,
-                ...gamesObj.value
-            }
+            updateGame(
+                {
+                    polygonEntries: newEntries,
+                    ...gamesObj.value,
+                } as GameRecord,
+                JSON.parse(JSON.stringify(gamesObj.value)),
+                gamesDbRef.value
             );
             drawingPolygon.value = false
         }

--- a/src/components/MapActionButton.vue
+++ b/src/components/MapActionButton.vue
@@ -132,5 +132,6 @@ code {
   bottom: 2.5em;
   left: 50%;
   transform: translate(-50%, -50%);
+  display: flex;
 }
 </style>

--- a/src/components/MapActionButton.vue
+++ b/src/components/MapActionButton.vue
@@ -73,7 +73,7 @@ const props = defineProps<{
 }>();
 
 import { shallowRef } from 'vue'
-import { useStore } from '@/stores/app';
+import { useUndoRedoStore } from '@/stores/app';
 
 defineEmits<{
   (e: 'radar', hit: boolean, lat: number, long: number, meters: number): void
@@ -92,7 +92,7 @@ const historyIsOpen = shallowRef(false)
 const thermometerIsOpen = shallowRef(false)
 const findClosestIsOpen = shallowRef(false)
 
-const store = useStore();
+const store = useUndoRedoStore();
 
 const canUndo = computed(() => store.$state.gameHistory.length > 1);
 const canRedo = computed(() => store.$state.undoHistory.length > 0);

--- a/src/components/MapActionButton.vue
+++ b/src/components/MapActionButton.vue
@@ -1,65 +1,71 @@
 <template>
-  <v-fab :absolute="true" :color="open ? '' : 'primary'" location="bottom center" size="large" extended
-    :prepend-icon="open ? 'mdi-close' : 'mdi-pencil'" width="16em">
-    Edit Map
-    <v-speed-dial v-model="open" location="top center" transition="slide-y-reverse-transition" activator="parent">
-
-      <v-btn key="4" color="purple-darken-4" prepend-icon="mdi-history" @click="historyIsOpen = true" spaced="start" width="14em">
-        History
-      </v-btn>
-
-      <v-btn key="4" color="orange-darken-4" prepend-icon="mdi-pin" @click="$emit('locate')"  spaced="start">
-        Locate
-      </v-btn>
-
-      <v-btn key="4" color="cyan-darken-4" prepend-icon="mdi-radar" @click="radarIsOpen = true"  spaced="start">
-        Radar
-      </v-btn>
-
-      <!-- <v-btn key="4" color="success" prepend-icon="mdi-thermometer" @click="thermometerIsOpen = true">
-        Thermometer
-      </v-btn> -->
-
-      <v-btn key="4" color="red-darken-2" prepend-icon="mdi-radius" @click="findClosestIsOpen = true"  spaced="start">
-        Find Closest
-      </v-btn>
+  <div class="fab-container">
+    <v-fab :color="open ? '' : 'primary'" size="large" extended
+      :prepend-icon="open ? 'mdi-close' : 'mdi-pencil'" width="12em">
+      Edit Map
+      <v-speed-dial v-model="open" location="top center" transition="slide-y-reverse-transition" activator="parent">
   
-      <v-btn key="4" color="info" prepend-icon="mdi-draw" @click="$emit('draw')"  spaced="start">
-        Draw
-      </v-btn>
+        <v-btn key="4" color="purple-darken-4" prepend-icon="mdi-history" @click="historyIsOpen = true" spaced="start" width="14em">
+          History
+        </v-btn>
   
-      <v-btn key="4" color="info" prepend-icon="mdi-pin" @click="$emit('showPinDrop')"  spaced="start">
-        Drop Pin
-      </v-btn>
-
-      <v-btn key="4" color="success" prepend-icon="mdi-information-outline" @click="markerEditorIsOpen = true"  spaced="start">
-        Markers
-      </v-btn>
-
-      <v-btn key="4" color="warning" prepend-icon="mdi-view-dashboard-edit-outline" @click="layerEditorIsOpen = true"  spaced="start">
-        Layers
-      </v-btn>
-
-      <v-btn key="4" color="error" prepend-icon="mdi-refresh" @click="$emit('reset')"  spaced="start">
-        Reset
-      </v-btn>
-    </v-speed-dial>
-    <marker-editor v-model="markerEditorIsOpen" />
-    <layer-editor v-model="layerEditorIsOpen" />
-    <find-closest v-model="findClosestIsOpen"
-      @find-closest="(key: string, type: string) => { findClosestIsOpen = false; $emit('findClosest', key, type) }" />
-    <radar v-model="radarIsOpen" post-title="Your Current Location"
-      @hit-success="(lat: number, long: number, meters: number) => $emit('radar', true, lat, long, meters)"
-      @hit-fail="(lat: number, long: number, meters: number) => $emit('radar', false, lat, long, meters)" />
-    <history :games-db-ref="gamesDbRef" :games-db-obj="gamesDbObj" v-model="historyIsOpen" />
-    <thermometer v-model="thermometerIsOpen"
-      @submit="(lat: number, long: number, angle: number, hotter: boolean) => $emit('thermometer', lat, long, angle, hotter)" />
-  </v-fab>
+        <v-btn key="4" color="orange-darken-4" prepend-icon="mdi-pin" @click="$emit('locate')"  spaced="start">
+          Locate
+        </v-btn>
+  
+        <v-btn key="4" color="cyan-darken-4" prepend-icon="mdi-radar" @click="radarIsOpen = true"  spaced="start">
+          Radar
+        </v-btn>
+  
+        <!-- <v-btn key="4" color="success" prepend-icon="mdi-thermometer" @click="thermometerIsOpen = true">
+          Thermometer
+        </v-btn> -->
+  
+        <v-btn key="4" color="red-darken-2" prepend-icon="mdi-radius" @click="findClosestIsOpen = true"  spaced="start">
+          Find Closest
+        </v-btn>
+    
+        <v-btn key="4" color="info" prepend-icon="mdi-draw" @click="$emit('draw')"  spaced="start">
+          Draw
+        </v-btn>
+    
+        <v-btn key="4" color="info" prepend-icon="mdi-pin" @click="$emit('showPinDrop')"  spaced="start">
+          Drop Pin
+        </v-btn>
+  
+        <v-btn key="4" color="success" prepend-icon="mdi-information-outline" @click="markerEditorIsOpen = true"  spaced="start">
+          Markers
+        </v-btn>
+  
+        <v-btn key="4" color="warning" prepend-icon="mdi-view-dashboard-edit-outline" @click="layerEditorIsOpen = true"  spaced="start">
+          Layers
+        </v-btn>
+  
+        <v-btn key="4" color="error" prepend-icon="mdi-refresh" @click="$emit('reset')"  spaced="start">
+          Reset
+        </v-btn>
+      </v-speed-dial>
+      <marker-editor v-model="markerEditorIsOpen" />
+      <layer-editor v-model="layerEditorIsOpen" />
+      <find-closest v-model="findClosestIsOpen"
+        @find-closest="(key: string, type: string) => { findClosestIsOpen = false; $emit('findClosest', key, type) }" />
+      <radar v-model="radarIsOpen" post-title="Your Current Location"
+        @hit-success="(lat: number, long: number, meters: number) => $emit('radar', true, lat, long, meters)"
+        @hit-fail="(lat: number, long: number, meters: number) => $emit('radar', false, lat, long, meters)" />
+      <history :games-db-ref="gamesDbRef" :games-db-obj="gamesDbObj" v-model="historyIsOpen" />
+      <thermometer v-model="thermometerIsOpen"
+        @submit="(lat: number, long: number, angle: number, hotter: boolean) => $emit('thermometer', lat, long, angle, hotter)" />
+    </v-fab>
+    
+    <v-fab color="deep-orange-darken-4" size="small" icon :disabled="!canUndo" @click="undoGame($props.gamesDbRef)"><v-icon>mdi-undo-variant</v-icon></v-fab>
+    <v-fab color="deep-orange-darken-4" size="small" icon :disabled="!canRedo" @click="redoGame($props.gamesDbRef)"><v-icon>mdi-redo-variant</v-icon></v-fab>
+  </div>
 </template>
 <script lang="ts" setup>
 import type { GameRecord } from '@/utils';
 import type { DatabaseReference } from 'firebase/database';
 import type { VueDatabaseDocumentData } from 'vuefire';
+import { undoGame, redoGame } from '@/game';
 
 const props = defineProps<{
   gamesDbRef: DatabaseReference,
@@ -67,6 +73,7 @@ const props = defineProps<{
 }>();
 
 import { shallowRef } from 'vue'
+import { useStore } from '@/stores/app';
 
 defineEmits<{
   (e: 'radar', hit: boolean, lat: number, long: number, meters: number): void
@@ -84,6 +91,11 @@ const radarIsOpen = shallowRef(false)
 const historyIsOpen = shallowRef(false)
 const thermometerIsOpen = shallowRef(false)
 const findClosestIsOpen = shallowRef(false)
+
+const store = useStore();
+
+const canUndo = computed(() => store.$state.gameHistory.length > 1);
+const canRedo = computed(() => store.$state.undoHistory.length > 0);
 
 </script>
 <style scoped>
@@ -111,12 +123,14 @@ code {
 }
 
 .v-fab {
-  z-index: 1000;
+  margin: 0.5em;
 }
-</style>
 
-<style>
-.v-fab.v-fab--bottom .v-fab__container {
-  bottom: 5em;
+.fab-container {
+  z-index: 1000;
+  position: fixed;
+  bottom: 2.5em;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 </style>

--- a/src/components/dialog/CustomPinLabelEditor.vue
+++ b/src/components/dialog/CustomPinLabelEditor.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script lang="ts" setup>
+import { updateGame } from '@/game';
 import type { GameRecord } from '@/utils';
 import { notify } from '@kyvg/vue3-notification';
 import { set, type DatabaseReference } from 'firebase/database';
@@ -43,14 +44,15 @@ const loading = shallowRef(false)
 const save = async() => {
   loading.value = true;
   const newObj: GameRecord = JSON.parse(JSON.stringify(props.gamesDbObj));
+  const oldObj: GameRecord = JSON.parse(JSON.stringify(props.gamesDbObj));
   const pinToEdit = newObj.customPins.find(pin => pin.lat === props.mostRecentPinDrop?.lat && pin.long === props.mostRecentPinDrop.lng);
   if (pinToEdit) {
     pinToEdit.customTitle = label.value;
   } else {
     console.error("Pin To Edit custom pin label is undefined for some reason");
   }
-  await set(
-    props.gamesDbRef, newObj
+  await updateGame(
+    newObj, oldObj, props.gamesDbRef, true
   );
   loading.value = false
   model.value = false

--- a/src/components/dialog/History.vue
+++ b/src/components/dialog/History.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script lang="ts" setup>
+import { updateGame } from '@/game';
 import type { GameRecord } from '@/utils';
 import { notify } from '@kyvg/vue3-notification';
 import { set, type DatabaseReference } from 'firebase/database';
@@ -82,9 +83,10 @@ const listItems = computed(() => events.value.sort((eventA, eventB) => new Date(
 const deleteSelectedEvents = async() => {
   loading.value = true
   const newObj: GameRecord = JSON.parse(JSON.stringify(props.gamesDbObj));
+  const oldObj: GameRecord = JSON.parse(JSON.stringify(props.gamesDbObj));
   selectedEvents.value.forEach(item => deleteEvent(item, newObj));
-  await set(
-    props.gamesDbRef, newObj
+  await updateGame(
+    newObj, oldObj, props.gamesDbRef
   );
   notify({
     title: "Success",

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -31,7 +31,7 @@ export const updateGame = async(newGameObject: GameRecord, oldGameObject: GameRe
     if (rewriteLast) {
         // This parameter is set to mean we don't want to track the previous action
         // For example, the custom pin drop and label operations are recorded separately, but
-        //  it is not useful to the user to undo the label operation. 
+        //  it is not useful to the user to undo the label operation.
         store.$state.gameHistory.pop();
     }
     store.$state.gameHistory.push(newGameObject);

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,0 +1,66 @@
+/**
+ * GAME STATE MANAGER
+ * 
+ * This file manages the undo and redo functionality for the game.
+ * 
+ * We maintain 2 stacks: A history stack and an undo stack.
+ *  We start by adding the "original" or "base" state to the history stack.
+ *  The first element in the history stack must always contain this base state.
+ * Every time we perform an operation, we push the new state the history stack.
+ *  This means that the top of the history stack will always contain the currently used game state.
+ * 
+ * To undo, we pop the latest off the top of the history stack and set the current game state
+ *  to the second-from-the-top element. We take this latest element and put it onto the undo stack.
+ * 
+ * To redo, we pop the latest off the top of the undo stack and set the game state to that.
+ */
+
+import { useStore } from "@/stores/app";
+import type { GameRecord } from "@/utils"
+import { set, type DatabaseReference } from "firebase/database"
+
+
+export const updateGame = async(newGameObject: GameRecord, oldGameObject: GameRecord, gamesDbRef: DatabaseReference, rewriteLast: boolean = false) => {
+    const store = useStore();
+    if (store.$state.gameHistory.length == 0) {
+        // Base case if the user loads the page for the first time
+        // Also add the old state to undo history
+        // TODO: Probably could be optimized better
+        store.$state.gameHistory.push(oldGameObject);
+    }
+    if (rewriteLast) {
+        // This parameter is set to mean we don't want to track the previous action
+        // For example, the custom pin drop and label operations are recorded separately, but
+        //  it is not useful to the user to undo the label operation. 
+        store.$state.gameHistory.pop();
+    }
+    store.$state.gameHistory.push(newGameObject);
+    // When you perform something new, you clear the Undo history (for redos)
+    store.$state.undoHistory = [];
+    await set(
+        gamesDbRef, newGameObject
+    );
+};
+
+export const undoGame = async(gamesDbRef: DatabaseReference) => {
+    const store = useStore();
+    if (store.$state.gameHistory.length < 2) {
+        throw "Cannot call Undo function when no history exists (history must contain base state and >= 1 operation)";
+    }
+    store.$state.undoHistory.push(store.$state.gameHistory.pop()!);
+    await set(
+        gamesDbRef, store.$state.gameHistory[store.$state.gameHistory.length - 1]
+    );
+}
+
+export const redoGame = async(gamesDbRef: DatabaseReference) => {
+    const store = useStore();
+    if (store.$state.undoHistory.length == 0) {
+        throw "Cannot call Redo function when no history exists";
+    }
+    const redoState = store.$state.undoHistory.pop()!;
+    store.$state.gameHistory.push(redoState);
+    await set(
+        gamesDbRef, redoState
+    );
+}

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -15,13 +15,13 @@
  * To redo, we pop the latest off the top of the undo stack and set the game state to that.
  */
 
-import { useStore } from "@/stores/app";
+import { useUndoRedoStore } from "@/stores/app";
 import type { GameRecord } from "@/utils"
 import { set, type DatabaseReference } from "firebase/database"
 
 
 export const updateGame = async(newGameObject: GameRecord, oldGameObject: GameRecord, gamesDbRef: DatabaseReference, rewriteLast: boolean = false) => {
-    const store = useStore();
+    const store = useUndoRedoStore();
     if (store.$state.gameHistory.length == 0) {
         // Base case if the user loads the page for the first time
         // Also add the old state to undo history
@@ -43,7 +43,7 @@ export const updateGame = async(newGameObject: GameRecord, oldGameObject: GameRe
 };
 
 export const undoGame = async(gamesDbRef: DatabaseReference) => {
-    const store = useStore();
+    const store = useUndoRedoStore();
     if (store.$state.gameHistory.length < 2) {
         throw "Cannot call Undo function when no history exists (history must contain base state and >= 1 operation)";
     }
@@ -54,7 +54,7 @@ export const undoGame = async(gamesDbRef: DatabaseReference) => {
 }
 
 export const redoGame = async(gamesDbRef: DatabaseReference) => {
-    const store = useStore();
+    const store = useUndoRedoStore();
     if (store.$state.undoHistory.length == 0) {
         throw "Cannot call Redo function when no history exists";
     }

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -11,8 +11,6 @@ type State = {
   enableStationCircles: boolean,
   regions: RegionDescriptor[],
   loadedRegionData: Region | null,
-  gameHistory: GameRecord[], // Used for Undo operation
-  undoHistory: GameRecord[], // Used for Redo operation ("undo the undo")
 };
 
 export const useStore = defineStore('app', {
@@ -25,8 +23,6 @@ export const useStore = defineStore('app', {
     enableStationCircles: false,
     regions: [],
     loadedRegionData: null,
-    gameHistory: [],
-    undoHistory: [],
   }),
   getters: {
     getMarkers() {
@@ -34,4 +30,21 @@ export const useStore = defineStore('app', {
     },
   },
   persist: true
+})
+
+// We use a separate state for Game History since we want it to clear when the browser refreshes.
+//  This prevents us from needing some limit on undo length and needing to clear when the game restarts.
+// Ultimately, the History page gives the user full power to delete things regardless.
+//  The undo/redo system is intended to be a convenience, not a core feature.
+type UndoRedoState = {
+  gameHistory: GameRecord[], // Used for Undo operation
+  undoHistory: GameRecord[], // Used for Redo operation ("undo the undo")
+}
+
+export const useUndoRedoStore = defineStore('undoRedo', {
+  state: (): UndoRedoState => ({
+    gameHistory: [],
+    undoHistory: []
+  }),
+  persist: false
 })

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -3,13 +3,16 @@ import { defineStore } from 'pinia'
 import type { CustomProperty, Region, RegionDescriptor } from '@/regions/regions';
 import type { Feature, Point } from 'geojson';
 import type { FeatureType } from '@/regions/features';
+import type { GameRecord } from '@/utils';
 
 type State = {
   mapLayers: string[]
   mapMarkers: string[],
   enableStationCircles: boolean,
   regions: RegionDescriptor[],
-  loadedRegionData: Region | null
+  loadedRegionData: Region | null,
+  gameHistory: GameRecord[], // Used for Undo operation
+  undoHistory: GameRecord[], // Used for Redo operation ("undo the undo")
 };
 
 export const useStore = defineStore('app', {
@@ -21,7 +24,9 @@ export const useStore = defineStore('app', {
     mapMarkers: [],
     enableStationCircles: false,
     regions: [],
-    loadedRegionData: null
+    loadedRegionData: null,
+    gameHistory: [],
+    undoHistory: [],
   }),
   getters: {
     getMarkers() {


### PR DESCRIPTION
This PR adds Undo and Redo buttons as a convenience to the user. The history resets on browser refresh. The history only includes when the local user enters into the game; other users' changes are not included (this was intentional).

Ultimately, the History dialog gives the true, in-depth ability to remove old actions from the game - this feature is just a convenience.  